### PR TITLE
Added Support for Directory with Spaces in Name

### DIFF
--- a/canonicalize_filename.sh
+++ b/canonicalize_filename.sh
@@ -23,7 +23,7 @@ function canonicalize_filename () {
     local result=""
 
     # Need to restore the working directory after work.
-    pushd `pwd` > /dev/null
+    pushd "`pwd`" > /dev/null
 
     cd "$(dirname "$target_file")"
     target_file=`basename $target_file`

--- a/pre-commit
+++ b/pre-commit
@@ -18,7 +18,7 @@ HOOKS="pre-commit-default pre-commit-compile pre-commit-uncrustify"
 ###########################################################
 # There should be no need to change anything below this line.
 
-source $(dirname "$0")/"canonicalize_filename.sh"
+source "$(dirname "$0")"/"canonicalize_filename.sh"
 
 # exit on error
 set -e


### PR DESCRIPTION
Using this script in a windows environment I found issues when it was located in a path that contained spaces. I'm not sure if this is the best way to fix this as I'm not familar with bash scripting but after Google'ing around and many tests I found this to work.
